### PR TITLE
Removed v8-r dependency from README (pacman)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ free to give the repo a star. *Think of the codegnomes.*
 
 Install dependencies:
 
-- Arch-based distros: `pacman -S make sdl2 sdl2_image lua v8-r lcms2`
+- Arch-based distros: `pacman -S make sdl2 sdl2_image lua lcms2`
 
 - Debian-based distros: `sudo apt-get install libsdl2-dev libsdl2-image-dev liblcms2-dev liblua5.3-dev libfreetype6-dev libnode-dev`
 


### PR DESCRIPTION
v8-r dependency is a part of AUR. And on Arch / Arch based distros this will result in 

`error: target not found: v8-r`

Also I didn't found any equivalent for this in ubuntu dependencies, and it does compile so I don't think this is needed anyway. In case it is needed please do mention that you have to use an AUR helper or makepkg -si for [this ](https://aur.archlinux.org/packages/v8-r) package