### PR TITLE
Automate Putting dylibs to .app directory

### DIFF
--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: 'true'
     - name: install-dependencies
-      run: brew install sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
+      run: brew install pkg-config sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
     - name: debug
       run: |
         pkg-config sdl2 --cflags

--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: 'true'
     - name: install-dependencies
-      run: brew install sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg
+      run: brew install sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
     - name: configure
       run: ./configure
     - name: make

--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -17,15 +17,19 @@ jobs:
         submodules: 'true'
     - name: install-dependencies
       run: brew install sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
-    - name: configure
-      run: ./configure
-    - name: make
-      run: MACOSX_DEPLOYMENT_TARGET=10.15 PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig" make -j 4
-    - name: package
-      run: ./package_macosx
-    - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dotto-development-macos-11-x86_64
-        path: Dotto.app
+    - name: debug
+      run: |
+        pkg-config --cflags
+        pkg-config --libs
+#     - name: configure
+#       run: ./configure
+#     - name: make
+#       run: MACOSX_DEPLOYMENT_TARGET=10.15 PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig" make -j 4
+#     - name: package
+#       run: ./package_macosx
+#     - name: Archive production artifacts
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: dotto-development-macos-11-x86_64
+#         path: Dotto.app
 

--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -19,8 +19,8 @@ jobs:
       run: brew install sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
     - name: debug
       run: |
-        pkg-config --cflags
-        pkg-config --libs
+        pkg-config sdl2 --cflags
+        pkg-config sdl2 --libs
 #     - name: configure
 #       run: ./configure
 #     - name: make

--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -28,3 +28,4 @@ jobs:
       with:
         name: dotto-development-macos-11-x86_64
         path: Dotto.app
+

--- a/.github/workflows/c-cpp-macos-x86_64.yml
+++ b/.github/workflows/c-cpp-macos-x86_64.yml
@@ -17,19 +17,15 @@ jobs:
         submodules: 'true'
     - name: install-dependencies
       run: brew install pkg-config sdl2 sdl2_image lcms2 freetype v8 openssl@1.1 lua@5.3 jpeg dylibbundler
-    - name: debug
-      run: |
-        pkg-config sdl2 --cflags
-        pkg-config sdl2 --libs
-#     - name: configure
-#       run: ./configure
-#     - name: make
-#       run: MACOSX_DEPLOYMENT_TARGET=10.15 PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig" make -j 4
-#     - name: package
-#       run: ./package_macosx
-#     - name: Archive production artifacts
-#       uses: actions/upload-artifact@v2
-#       with:
-#         name: dotto-development-macos-11-x86_64
-#         path: Dotto.app
+    - name: configure
+      run: ./configure
+    - name: make
+      run: MACOSX_DEPLOYMENT_TARGET=10.15 PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig" make -j 4
+    - name: package
+      run: ./package_macosx
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: dotto-development-macos-11-x86_64
+        path: Dotto.app
 

--- a/package_macosx
+++ b/package_macosx
@@ -24,39 +24,5 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>' > $package/Contents/Info.plist
 
-
-
-# List from:
-# DYLD_PRINT_LIBRARIES=1 DYLD_PRINT_LIBRARIES_POST_LAUNCH=1 ./dotto > /dev/null
-
-declare -a dependencies=(
-"/usr/local/opt/libpng/lib/libpng16.16.dylib"
-"/usr/local/opt/lua/lib/liblua.dylib"
-"/usr/local/opt/freetype/lib/libfreetype.6.dylib"
-"/usr/local/opt/jpeg/lib/libjpeg.9.dylib"
-"/usr/local/opt/libtiff/lib/libtiff.5.dylib"
-"/usr/local/opt/webp/lib/libwebp.7.dylib"
-"/usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib"
-"/usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib"
-"/usr/local/opt/little-cms2/lib/liblcms2.2.dylib"
-"/usr/local/opt/openssl/lib/libssl.1.1.dylib"
-"/usr/local/opt/openssl/lib/libcrypto.1.1.dylib"
-
-"/usr/local/Cellar/lua@5.3/5.3.6/lib/liblua.dylib"
-"/usr/local/Cellar/jpeg/9e/lib/libjpeg.9.dylib"
-"/usr/local/Cellar/openssl@1.1/1.1.1s/lib/libssl.1.1.dylib"
-"/usr/local/Cellar/openssl@1.1/1.1.1s/lib/libcrypto.1.1.dylib"
-)
-
-for srcname in "${dependencies[@]}"
-do
-   filename=$(basename $srcname)
-   echo "Adding dependency $srcname"
-   install_name_tool -change $srcname $filename $macos/dotto
-   cp $srcname $macos
-   chmod +w "$macos/$filename"
-   for depname in "${dependencies[@]}"
-   do
-      install_name_tool -change $depname $(basename $depname) "$macos/$filename"
-   done
-done
+mkdir -p $package/Contents/libs/
+dylibbundler -od -b -ns -x $macos/dotto -d $package/Contents/libs/


### PR DESCRIPTION
this pr uses [dylibbundler](https://github.com/auriamg/macdylibbundler) to automate the task of putting the dylibs required by the dotto binary into the .app directory.

this allows us to use more dependencies without needing to update the `package_macosx` script.