### PR TITLE
Make Makefile Build Output More Clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,20 +170,24 @@ OBJ += $(patsubst %,$(ODIR)/%.o,$(C_FILES))
 DEP := $(OBJ:.o=.d)
 
 $(ODIR)/%.cpp.o: %.cpp
+    $(info CXX - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CXX) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
+	@$(CXX) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
 
 $(ODIR)/%.c.o: %.c
+    $(info CC   - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CC) -c $< -o $@ $(FLAGS) $(C_FLAGS)
+	@$(CC) -c $< -o $@ $(FLAGS) $(C_FLAGS)
 
 $(ODIR)/%.mm.o: %.mm
+    $(info OBJC - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(OBJC) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
+	@$(OBJC) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
 
 $(DOTTO): $(OBJ)
-	$(LN) $^ -o $@ $(FLAGS) $(LN_FLAGS)
-	$(POSTBUILD)
+    $(info Linking $@)
+	@$(LN) $^ -o $@ $(FLAGS) $(LN_FLAGS)
+	@$(POSTBUILD)
 
 .PHONY: clean
 

--- a/Makefile
+++ b/Makefile
@@ -170,22 +170,22 @@ OBJ += $(patsubst %,$(ODIR)/%.o,$(C_FILES))
 DEP := $(OBJ:.o=.d)
 
 $(ODIR)/%.cpp.o: %.cpp
-    $(info CXX - $<)
+	$(info CXX - $<)
 	@mkdir -p "$$(dirname "$@")"
 	@$(CXX) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
 
 $(ODIR)/%.c.o: %.c
-    $(info CC   - $<)
+	$(info CC   - $<)
 	@mkdir -p "$$(dirname "$@")"
 	@$(CC) -c $< -o $@ $(FLAGS) $(C_FLAGS)
 
 $(ODIR)/%.mm.o: %.mm
-    $(info OBJC - $<)
+	$(info OBJC - $<)
 	@mkdir -p "$$(dirname "$@")"
 	@$(OBJC) -c $< -o $@ $(FLAGS) $(CPP_FLAGS)
 
 $(DOTTO): $(OBJ)
-    $(info Linking $@)
+	$(info Linking $@)
 	@$(LN) $^ -o $@ $(FLAGS) $(LN_FLAGS)
 	@$(POSTBUILD)
 

--- a/Makefile.3ds
+++ b/Makefile.3ds
@@ -91,20 +91,24 @@ OBJ += $(patsubst %,$(ODIR)/%.o,$(C_FILES))
 DEP := $(OBJ:.o=.d)
 
 $(ODIR)/%.cpp.o: %.cpp
+	$(info CXX - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CPP) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
+	@$(CPP) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
 
 $(ODIR)/%.c.o: %.c
+	$(info CC   - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CC) $(FLAGS) $(C_FLAGS) -c $< -o $@
+	@$(CC) $(FLAGS) $(C_FLAGS) -c $< -o $@
 
 $(ODIR)/%.mm.o: %.mm
+	$(info OBJC - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(OBJC) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
+	@$(OBJC) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
 
 $(DOTTO): $(OBJ)
-	$(LN) $(FLAGS) $^ -o $@ $(LN_FLAGS)
-	$(POSTBUILD)
+	$(info Linking $@)
+	@$(LN) $(FLAGS) $^ -o $@ $(LN_FLAGS)
+	@$(POSTBUILD)
 
 .PHONY: clean
 

--- a/Makefile.wasm
+++ b/Makefile.wasm
@@ -69,20 +69,24 @@ OBJ += $(patsubst %,$(ODIR)/%.o,$(C_FILES))
 DEP := $(OBJ:.o=.d)
 
 $(ODIR)/%.cpp.o: %.cpp
+	$(info CXX - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CXX) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
+	@$(CXX) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
 
 $(ODIR)/%.c.o: %.c
+	$(info CC   - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(CC) $(FLAGS) $(C_FLAGS) -c $< -o $@
+	@$(CC) $(FLAGS) $(C_FLAGS) -c $< -o $@
 
 $(ODIR)/%.mm.o: %.mm
+	$(info OBJC - $<)
 	@mkdir -p "$$(dirname "$@")"
-	$(OBJC) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
+	@$(OBJC) $(FLAGS) $(CPP_FLAGS) -c $< -o $@
 
 $(DOTTO): $(OBJ)
-	$(LN) $(FLAGS) $^ -o $@ $(LN_FLAGS)
-	$(POSTBUILD)
+	$(info Linking $@)
+	@$(LN) $(FLAGS) $^ -o $@ $(LN_FLAGS)
+	@$(POSTBUILD)
 
 .PHONY: clean
 


### PR DESCRIPTION
This PR Aims To make the output of the Makefile builds more clean, so now when building, the output is:

```bash
CXX - src/parsers/IniParser.cpp
CXX - src/parsers/PngParser.cpp
CXX - src/parsers/SDLImageParser.cpp
CXX - src/parsers/TTFParser.cpp
CXX - src/parsers/ICCParser.cpp
CXX - src/parsers/XmlParser.cpp
CXX - src/parsers/GPLParser.cpp
CXX - src/parsers/TXTParser.cpp
CXX - src/parsers/PALParser.cpp
CXX - src/parsers/QoiParser.cpp
CXX - src/parsers/ScriptParser.cpp
CXX - src/layer/BitmapLayer.cpp
CXX - src/layer/GroupLayer.cpp
CXX - src/tools/Bucket.cpp
CXX - src/tools/Pencil.cpp
CXX - src/tools/Tool.cpp
CXX - src/tools/Script.cpp
CXX - src/tools/Marquee.cpp
CXX - src/tools/Eraser.cpp
CXX - src/filters/Flip.cpp
CXX - src/filters/Blur.cpp
CXX - src/filters/DropShadow.cpp
CXX - src/filters/CanvasResize.cpp
CXX - src/script/api/PropertySetScriptObject.cpp
CXX - src/script/api/ConfigScriptObject.cpp
CXX - src/script/api/SurfaceScriptObject.cpp
CXX - src/script/api/ShellScriptObject.cpp
CXX - src/fs/Cache.cpp
CXX - src/fs/FileSystem.cpp
CXX - src/fs/FSEntity.cpp
CXX - src/fs/Folder.cpp
CXX - src/blender/Darken.cpp
CXX - src/blender/Overlay.cpp
CXX - src/blender/Screen.cpp
CXX - src/blender/Multiply.cpp
CXX - src/blender/Lighten.cpp
CXX - src/blender/Erase.cpp
CXX - src/blender/HardLight.cpp
CXX - src/blender/SoftLight.cpp
CXX - src/blender/Normal.cpp
CXX - src/doc/GroupCell.cpp
CXX - src/doc/Selection.cpp
CXX - src/doc/Timeline.cpp
CXX - src/gui/controllers/ActivateToolButton.cpp
CXX - src/gui/controllers/Scrollable.cpp
CXX - src/gui/controllers/Shortcut.cpp
CXX - src/gui/controllers/CellPropertyModifier.cpp
CXX - src/gui/controllers/Range.cpp
CXX - src/gui/controllers/BlurRemove.cpp
CXX - src/gui/controllers/Debug.cpp
CXX - src/gui/controllers/Script.cpp
CXX - src/gui/controllers/FPS.cpp
CXX - src/cmd/IncreaseToolSize.cpp
CXX - src/cmd/ActivateFilter.cpp
CXX - src/cmd/SetCellProperty.cpp
CXX - src/cmd/Paint.cpp
CXX - src/cmd/Zoom.cpp
CXX - src/cmd/ToggleIDE.cpp
CXX - src/cmd/LoadPalette.cpp
CXX - src/cmd/ActivateTool.cpp
CXX - src/cmd/ActivateColor.cpp
CXX - src/cmd/ToggleGrid.cpp
CXX - src/cmd/SelectNone.cpp
Linking dotto
```

errors and everything show up beautifully...

the PR simply uses `@` symbol which makes it possible for that particular line to not be echoed in the terminal.