### PR TITLE
Automate Copying Libraries For The Executable on Windows

### DIFF
--- a/.github/workflows/c-cpp-windows-i686.yml
+++ b/.github/workflows/c-cpp-windows-i686.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
     - uses: msys2/setup-msys2@v2
       with:
@@ -18,9 +19,9 @@ jobs:
         release: false
         update: false
         install: >-
-          base-devel
-          git
+          base-devel git
           mingw-w64-i686-gcc
+          mingw-w64-i686-python
           mingw-w64-i686-openssl
           mingw-w64-i686-v8 
           mingw-w64-i686-icu
@@ -29,48 +30,20 @@ jobs:
           mingw-w64-i686-lcms2 
           mingw-w64-i686-freetype
           mingw-w64-i686-glew
+
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
-    - shell: msys2 {0}
+
+    - name: make
       run: |
         make -j 4
-        cp /mingw32/bin/libgcc_s_dw2-1.dll ./
-        cp /mingw32/bin/libstdc++-*.dll ./
-        cp /mingw32/bin/libwinpthread-1.dll ./
-        cp /mingw32/bin/libfreetype-6.dll ./
-        cp /mingw32/bin/liblcms2-*.dll ./
-        cp /mingw32/bin/glew32.dll ./
-        cp /mingw32/bin/libpng*.dll ./
-        cp /mingw32/bin/libv8.dll ./
-        cp /mingw32/bin/SDL2_image.dll ./
-        cp /mingw32/bin/SDL2.dll ./
-        cp /mingw32/bin/libv8_libplatform.dll ./
-        cp /mingw32/bin/libbz2-*.dll ./
-        cp /mingw32/bin/libbrotli*.dll ./
-        cp /mingw32/bin/libharfbuzz-*.dll ./
-        cp /mingw32/bin/zlib1.dll ./
-        cp /mingw32/bin/libwebp-*.dll ./
-        cp /mingw32/bin/libjpeg-*.dll ./
-        cp /mingw32/bin/libtiff-*.dll ./
-        cp /mingw32/bin/libv8_libbase.dll ./
-        cp /mingw32/bin/libcrypto-*.dll ./
-        cp /mingw32/bin/libssl-*.dll ./
-        cp /mingw32/bin/libicuin*.dll ./
-        cp /mingw32/bin/libicuuc*.dll ./
-        cp /mingw32/bin/libicudt*.dll ./
-        cp /mingw32/bin/libpcre*.dll ./
-        cp /mingw32/bin/libintl-*.dll ./
-        cp /mingw32/bin/libiconv-*.dll ./
-        cp /mingw32/bin/libglib-*.dll ./
-        cp /mingw32/bin/libgraphite2.dll ./
-        cp /mingw32/bin/libdeflate.dll ./
-        cp /mingw32/bin/libjbig-*.dll ./
-        cp /mingw32/bin/libjxl*.dll ./
-        cp /mingw32/bin/libLerc.dll ./
-        cp /mingw32/bin/libzstd.dll ./
-        cp /mingw32/bin/liblzma-*.dll ./
+
+    - name: Copy Dependencies
+        curl -L https://raw.githubusercontent.com/pegvin/mingw-bundledlls/master/mingw-bundledlls --output ./bundledlls.py
+        python3 ./bundledlls.py --copy ./dotto.exe --search-dir /mingw32/bin/
         cp /mingw32/bin/snapshot_blob.bin ./
+
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2
       with:
@@ -80,3 +53,5 @@ jobs:
           data
           snapshot_blob.bin
           *.dll
+
+


### PR DESCRIPTION
this PR aims to automate the process of copying libraries (.dll files) required by the final executable when building on windows.

this uses a python script named [mingw-bundledlls](https://github.com/mpreisler/mingw-bundledlls) and is now maintained by me [here](https://github.com/pegvin/mingw-bundledlls/).

if any further breaking changes are made to the script i will raise a PR (if not by anybody else) updating the workflow.
