### PR TITLE
Automate Copying Libraries For The Executable on Windows

### DIFF
--- a/.github/workflows/c-cpp-windows-i686.yml
+++ b/.github/workflows/c-cpp-windows-i686.yml
@@ -8,19 +8,21 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW32
-        release: false
+        release: true
         update: false
+        path-type: strict
         install: >-
-          base-devel
-          git
+          base-devel git
           mingw-w64-i686-gcc
+          mingw-w64-i686-nodejs
           mingw-w64-i686-openssl
           mingw-w64-i686-v8 
           mingw-w64-i686-icu
@@ -29,48 +31,21 @@ jobs:
           mingw-w64-i686-lcms2 
           mingw-w64-i686-freetype
           mingw-w64-i686-glew
+
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
-    - shell: msys2 {0}
+
+    - name: make
+      run: make -j4
+
+    - name: Copy Dependencies
       run: |
-        make -j 4
-        cp /mingw32/bin/libgcc_s_dw2-1.dll ./
-        cp /mingw32/bin/libstdc++-*.dll ./
-        cp /mingw32/bin/libwinpthread-1.dll ./
-        cp /mingw32/bin/libfreetype-6.dll ./
-        cp /mingw32/bin/liblcms2-*.dll ./
-        cp /mingw32/bin/glew32.dll ./
-        cp /mingw32/bin/libpng*.dll ./
-        cp /mingw32/bin/libv8.dll ./
-        cp /mingw32/bin/SDL2_image.dll ./
-        cp /mingw32/bin/SDL2.dll ./
-        cp /mingw32/bin/libv8_libplatform.dll ./
-        cp /mingw32/bin/libbz2-*.dll ./
-        cp /mingw32/bin/libbrotli*.dll ./
-        cp /mingw32/bin/libharfbuzz-*.dll ./
-        cp /mingw32/bin/zlib1.dll ./
-        cp /mingw32/bin/libwebp-*.dll ./
-        cp /mingw32/bin/libjpeg-*.dll ./
-        cp /mingw32/bin/libtiff-*.dll ./
-        cp /mingw32/bin/libv8_libbase.dll ./
-        cp /mingw32/bin/libcrypto-*.dll ./
-        cp /mingw32/bin/libssl-*.dll ./
-        cp /mingw32/bin/libicuin*.dll ./
-        cp /mingw32/bin/libicuuc*.dll ./
-        cp /mingw32/bin/libicudt*.dll ./
-        cp /mingw32/bin/libpcre*.dll ./
-        cp /mingw32/bin/libintl-*.dll ./
-        cp /mingw32/bin/libiconv-*.dll ./
-        cp /mingw32/bin/libglib-*.dll ./
-        cp /mingw32/bin/libgraphite2.dll ./
-        cp /mingw32/bin/libdeflate.dll ./
-        cp /mingw32/bin/libjbig-*.dll ./
-        cp /mingw32/bin/libjxl*.dll ./
-        cp /mingw32/bin/libLerc.dll ./
-        cp /mingw32/bin/libzstd.dll ./
-        cp /mingw32/bin/liblzma-*.dll ./
         cp /mingw32/bin/snapshot_blob.bin ./
+        rm -f ./bundledlls.js
+        curl -L https://raw.githubusercontent.com/pegvin/mingw-bundledlls/master/bundledll.js --output ./bundledlls.js
+        node ./bundledlls.js --copy ./dotto.exe
+
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
this PR aims to automate the process of copying libraries (.dll files) required by the final executable when building on windows.

This uses a JS script named [bundledll.js](https://github.com/pegvin/mingw-bundledlls) which is a modified version re-written in JS of the [mingw-bundledlls](https://github.com/mpreisler/mingw-bundledlls) python script.

if any further breaking changes are made to the script i will raise a PR (if not by anybody else) updating the workflow.
